### PR TITLE
Add link to master-projekttag page

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -54,7 +54,7 @@ const Layout = ({ children, title, childrenInScreenVH }: ILayout) => {
                     </Link>
                 </div>
                 <div className="flex items-center space-x-16 text-white-soft text-3xl font-medium">
-                    <a className="text-white-soft border-b-4 border-transparent hover:border-white-soft transition duration-100" href="#">
+                    <a className="text-white-soft border-b-4 border-transparent hover:border-white-soft transition duration-100" href="https://www.informatik.uni-bremen.de/projekttag/2022_ma/de/">
                         { t`common:projekttag.master-title` }
                     </a>
                     <a className="text-white-soft border-b-4 border-transparent hover:border-white-soft transition duration-100" href="https://www.informatik.uni-bremen.de/projekttag/2021/">

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -83,7 +83,7 @@
         "title": "Klingt Interessant?",
         "button-label": {
             "bachelor": "Zum digitalen Bachelor Projekttag",
-            "master": "Zum Master Projekttag (soon™)"
+            "master": "Zum Master Projekttag"
         }
     },
     "imprint": {
@@ -93,7 +93,7 @@
     },
     "projekttag": {
         "bachelor-title": "Bachelor Projekttag",
-        "master-title": "Master Projekttag (soon™)",
+        "master-title": "Master Projekttag",
         "redirecting": "Umleitung...",
         "no-js-click-here": "Klicken Sie hier, wenn Sie JavaScript deaktiviert haben:"
     }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -83,7 +83,7 @@
         "title": "Sounds Interesting?",
         "button-label": {
             "bachelor": "To the digital Bachelor project day",
-            "master": "To the Master project day (soon™)"
+            "master": "To the Master project day"
         }
     },
     "imprint": {
@@ -93,7 +93,7 @@
     },
     "projekttag": {
         "bachelor-title": "Bachelor project day",
-        "master-title": "Master project day (soon™)",
+        "master-title": "Master project day",
         "redirecting": "Redirecting...",
         "no-js-click-here": "Click here if you have JavaScript disabled:"
     }

--- a/pages_/index.tsx
+++ b/pages_/index.tsx
@@ -163,7 +163,7 @@ const IndexPage = () => {
                 <a href="https://www.informatik.uni-bremen.de/projekttag/2021/" className="mr-6">
                     <Button size={ ButtonSize.XL }>{ t`common:cta.button-label.bachelor` }</Button>
                 </a>
-                <a href="#">
+                <a href="https://www.informatik.uni-bremen.de/projekttag/2022_ma/de/">
                     <Button size={ ButtonSize.XL }>{ t`common:cta.button-label.master` }</Button>
                 </a>
             </section>


### PR DESCRIPTION
This PR just adds the correct URL for the webpage of the master project day to the NAMIB webpage.

*Note about the /de/ in the link: There is no English version of the webpage, so it should always be like in the committed URL.*